### PR TITLE
Add structured location support for suggestions

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -20,9 +20,9 @@ class Settings(BaseSettings):
     # CORS - Allow production domains
     CORS_ORIGINS: str = os.getenv(
         "CORS_ORIGINS",
-        "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173"
+        "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173",
     )
-    
+
     @property
     def cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS string into a list"""
@@ -57,6 +57,11 @@ class Settings(BaseSettings):
     RATE_LIMIT_ENABLED: bool = False
     RATE_LIMIT_REQUESTS: int = 100
     RATE_LIMIT_PERIOD: int = 60  # seconds
+
+    # Feature Flags
+    ENABLE_STRUCTURED_LOCATION: bool = (
+        os.getenv("ENABLE_STRUCTURED_LOCATION", "false").lower() == "true"
+    )
 
     class Config:
         env_file = ".env"

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,7 +2,17 @@ import uuid
 from datetime import datetime
 
 from database import Base
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 
@@ -117,6 +127,13 @@ class Suggestion(Base):
     title = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     location = Column(String, nullable=True)
+    structured_location = Column(JSON, nullable=True)
+    latitude = Column(Float, nullable=True)
+    longitude = Column(Float, nullable=True)
+    map_bounds = Column(JSON, nullable=True)
+    geo_source = Column(String, nullable=True)
+    location_confidence = Column(Integer, nullable=True)
+    location_last_verified_at = Column(DateTime, nullable=True)
     estimated_cost = Column(String, nullable=True)  # e.g., "$", "$$", "$$$"
 
     # Status

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, validator
 
@@ -129,6 +129,13 @@ class SuggestionCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=200)
     description: Optional[str] = Field(None, max_length=1000)
     location: Optional[str] = Field(None, max_length=200)
+    structured_location: Optional[Dict[str, Any]] = None
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    map_bounds: Optional[Dict[str, Any]] = None
+    geo_source: Optional[str] = Field(None, max_length=50)
+    location_confidence: Optional[int] = Field(None, ge=0, le=100)
+    location_last_verified_at: Optional[datetime] = None
     estimated_cost: Optional[str] = Field(
         None, pattern="^(\\$|\\$\\$|\\$\\$\\$|\\$\\$\\$\\$|Free)$"
     )
@@ -140,6 +147,13 @@ class SuggestionUpdate(BaseModel):
     title: Optional[str] = Field(None, min_length=1, max_length=200)
     description: Optional[str] = Field(None, max_length=1000)
     location: Optional[str] = Field(None, max_length=200)
+    structured_location: Optional[Dict[str, Any]] = None
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    map_bounds: Optional[Dict[str, Any]] = None
+    geo_source: Optional[str] = Field(None, max_length=50)
+    location_confidence: Optional[int] = Field(None, ge=0, le=100)
+    location_last_verified_at: Optional[datetime] = None
     estimated_cost: Optional[str] = Field(
         None, pattern="^(\\$|\\$\\$|\\$\\$\\$|\\$\\$\\$\\$|Free)$"
     )
@@ -153,6 +167,13 @@ class SuggestionResponse(BaseModel):
     title: str
     description: Optional[str]
     location: Optional[str]
+    structured_location: Optional[Dict[str, Any]]
+    latitude: Optional[float]
+    longitude: Optional[float]
+    map_bounds: Optional[Dict[str, Any]]
+    geo_source: Optional[str]
+    location_confidence: Optional[int]
+    location_last_verified_at: Optional[datetime]
     estimated_cost: Optional[str]
     is_active: bool
     created_at: datetime

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -55,7 +55,11 @@ Set `.env.local`:
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_APP_NAME=PickleJar
 NEXT_PUBLIC_SMS_VERIFICATION_ENABLED=false
+NEXT_PUBLIC_MAPBOX_TOKEN=pk.yourPublicTokenFromMapbox
+NEXT_PUBLIC_ENABLE_STRUCTURED_LOCATION=false
 ```
+
+Set `NEXT_PUBLIC_ENABLE_STRUCTURED_LOCATION=true` locally when you want to exercise the Mapbox-powered location picker on `/jar/[id]/suggest`. That picker also requires `NEXT_PUBLIC_MAPBOX_TOKEN` to be present; the frontend only sends the public token and the backend remains the source of truth for structured location columns.
 
 ---
 

--- a/frontend/app/components/LocationPicker.tsx
+++ b/frontend/app/components/LocationPicker.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+
+import type {
+  Coordinate,
+  LocationPickerValue,
+  StructuredLocation,
+} from "../types/location";
+import {
+  hasMapboxToken,
+  normalizeMapboxFeature,
+  searchMapboxPlaces,
+  type MapboxFeature,
+} from "../lib/mapbox";
+
+type LocationPickerProps = {
+  value: LocationPickerValue;
+  onChange: (value: LocationPickerValue) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  inputId?: string;
+  minimumQueryLength?: number;
+  debounceMs?: number;
+  autocompleteEnabled?: boolean;
+  className?: string;
+  proximity?: Coordinate | null;
+};
+
+type Suggestion = {
+  id: string;
+  primary: string;
+  secondary?: string;
+  structured: StructuredLocation;
+};
+
+const DEFAULT_MIN_QUERY = 2;
+const DEFAULT_DEBOUNCE_MS = 250;
+
+export function LocationPicker({
+  value,
+  onChange,
+  disabled = false,
+  placeholder = "Search for a place or venue",
+  inputId,
+  minimumQueryLength = DEFAULT_MIN_QUERY,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  autocompleteEnabled = true,
+  className,
+  proximity,
+}: LocationPickerProps) {
+  const tokenAvailable = hasMapboxToken();
+  const isAutocompleteActive = tokenAvailable && autocompleteEnabled;
+  const [query, setQuery] = useState(value.freeform ?? "");
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortController = useRef<AbortController | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isFeatureDisabled = disabled || !isAutocompleteActive;
+
+  const hasSelection = Boolean(value.structured);
+  const showSuggestions =
+    !isFeatureDisabled &&
+    suggestions.length > 0 &&
+    query.length >= minimumQueryLength;
+
+  useEffect(() => {
+    setQuery(
+      value.freeform ??
+        value.structured?.address ??
+        value.structured?.name ??
+        "",
+    );
+  }, [value.freeform, value.structured]);
+
+  const clearSuggestions = useCallback(() => {
+    setSuggestions([]);
+    setError(null);
+    if (abortController.current) {
+      abortController.current.abort();
+      abortController.current = null;
+    }
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+  }, []);
+
+  const fetchSuggestions = useCallback(
+    async (nextQuery: string) => {
+      if (nextQuery.trim().length < minimumQueryLength) {
+        clearSuggestions();
+        return;
+      }
+
+      if (abortController.current) {
+        abortController.current.abort();
+      }
+
+      const controller = new AbortController();
+      abortController.current = controller;
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const features = await searchMapboxPlaces(nextQuery, {
+          limit: 5,
+          signal: controller.signal,
+          proximity: proximity
+            ? [proximity.longitude, proximity.latitude]
+            : undefined,
+        });
+        const mapped = features.map(convertFeatureToSuggestion);
+        setSuggestions(mapped);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {
+          return;
+        }
+        console.error("Mapbox search failed", err);
+        setError("Unable to fetch places. Try again in a moment.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [clearSuggestions, minimumQueryLength, proximity],
+  );
+
+  const handleQueryChange = useCallback(
+    (nextValue: string) => {
+      setQuery(nextValue);
+      onChange({
+        freeform: nextValue,
+        structured: undefined,
+      });
+
+      if (isFeatureDisabled) {
+        return;
+      }
+
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+      }
+
+      debounceTimer.current = setTimeout(() => {
+        fetchSuggestions(nextValue);
+      }, debounceMs);
+    },
+    [debounceMs, fetchSuggestions, isFeatureDisabled, onChange],
+  );
+
+  const handleSelect = useCallback(
+    (suggestion: Suggestion) => {
+      clearSuggestions();
+      setQuery(suggestion.secondary ?? suggestion.primary);
+      onChange({
+        freeform: suggestion.secondary ?? suggestion.primary,
+        structured: suggestion.structured,
+      });
+    },
+    [clearSuggestions, onChange],
+  );
+
+  const handleBlur = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+  }, []);
+
+  const handleClear = useCallback(() => {
+    clearSuggestions();
+    setQuery("");
+    onChange({ freeform: "", structured: undefined });
+  }, [clearSuggestions, onChange]);
+
+  const helperText = useMemo(() => {
+    if (!autocompleteEnabled) {
+      return "Location search disabled. You can still type anything in the field.";
+    }
+    if (!tokenAvailable) {
+      return "Map search unavailable. You can still type anything in the field.";
+    }
+    if (error) {
+      return error;
+    }
+    if (hasSelection) {
+      return "Location captured with coordinates.";
+    }
+    return undefined;
+  }, [autocompleteEnabled, error, hasSelection, tokenAvailable]);
+
+  return (
+    <div className={clsx("space-y-2", className)}>
+      <div className="relative">
+        <input
+          id={inputId}
+          type="text"
+          value={query}
+          onChange={(event) => handleQueryChange(event.target.value)}
+          onBlur={handleBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={clsx(
+            "w-full border-b-2 bg-transparent py-2 pr-14 text-xl md:text-2xl text-gray-900 placeholder-gray-400 focus:outline-none transition-colors",
+            disabled
+              ? "border-gray-200 text-gray-400"
+              : "border-gray-300 focus:border-gray-900",
+          )}
+          aria-autocomplete="list"
+          aria-expanded={showSuggestions}
+        />
+        {query && !disabled && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="absolute right-0 top-1/2 -translate-y-1/2 text-sm text-gray-500 hover:text-gray-900"
+          >
+            Clear
+          </button>
+        )}
+        {isLoading && (
+          <div className="absolute right-16 top-1/2 -translate-y-1/2 text-sm text-gray-400">
+            Searching…
+          </div>
+        )}
+      </div>
+
+      {helperText && (
+        <p
+          className={clsx(
+            "text-sm",
+            disabled || !autocompleteEnabled
+              ? "text-gray-500"
+              : error || !tokenAvailable
+                ? "text-red-600"
+                : "text-green-600",
+          )}
+        >
+          {helperText}
+        </p>
+      )}
+
+      {showSuggestions && (
+        <ul className="border border-gray-200 rounded-lg divide-y divide-gray-100 shadow-lg bg-white">
+          {suggestions.map((suggestion) => (
+            <li key={suggestion.id}>
+              <button
+                type="button"
+                className="w-full text-left px-4 py-3 hover:bg-gray-50 transition-colors"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => handleSelect(suggestion)}
+              >
+                <p className="text-base font-medium text-gray-900">
+                  {suggestion.primary}
+                </p>
+                {suggestion.secondary && (
+                  <p className="text-sm text-gray-500">
+                    {suggestion.secondary}
+                  </p>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function convertFeatureToSuggestion(feature: MapboxFeature): Suggestion {
+  const structured = normalizeMapboxFeature(feature);
+
+  return {
+    id: feature.id,
+    primary: structured.name,
+    secondary: structured.address,
+    structured,
+  };
+}

--- a/frontend/app/lib/mapbox.ts
+++ b/frontend/app/lib/mapbox.ts
@@ -1,0 +1,168 @@
+import type {
+  MapBounds,
+  StructuredLocation,
+  SuggestionLocationPayload,
+} from "../types/location";
+
+const MAPBOX_GEOCODING_URL =
+  "https://api.mapbox.com/geocoding/v5/mapbox.places";
+
+type MapboxCoordinates = [longitude: number, latitude: number];
+type MapboxBbox = [west: number, south: number, east: number, north: number];
+
+export type MapboxFeature = {
+  id: string;
+  type: "Feature";
+  text: string;
+  place_name: string;
+  place_type: string[];
+  relevance?: number;
+  geometry: {
+    type: "Point";
+    coordinates: MapboxCoordinates;
+    bbox?: MapboxBbox;
+  };
+  bbox?: MapboxBbox;
+  properties?: Record<string, unknown>;
+  context?: Array<{ id: string; text: string }>;
+};
+
+export type MapboxGeocodingResponse = {
+  type: "FeatureCollection";
+  query: string[];
+  features: MapboxFeature[];
+  attribution?: string;
+};
+
+export type MapboxSearchOptions = {
+  proximity?: MapboxCoordinates;
+  types?: string;
+  limit?: number;
+  sessionToken?: string;
+  language?: string;
+  signal?: AbortSignal;
+};
+
+const DEFAULT_LIMIT = 5;
+
+function getMapboxToken(): string {
+  const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  if (!token) {
+    throw new Error(
+      "NEXT_PUBLIC_MAPBOX_TOKEN is not set. Add it to your frontend environment before enabling the location picker.",
+    );
+  }
+  return token;
+}
+
+export function hasMapboxToken(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_MAPBOX_TOKEN);
+}
+
+export async function searchMapboxPlaces(
+  query: string,
+  options: MapboxSearchOptions = {},
+): Promise<MapboxFeature[]> {
+  if (!query.trim()) {
+    return [];
+  }
+
+  const token = getMapboxToken();
+  const params = new URLSearchParams({
+    access_token: token,
+    autocomplete: "true",
+    limit: String(options.limit ?? DEFAULT_LIMIT),
+    language: options.language ?? "en",
+  });
+
+  if (options.proximity) {
+    const [lng, lat] = options.proximity;
+    params.set("proximity", `${lng},${lat}`);
+  }
+
+  if (options.types) {
+    params.set("types", options.types);
+  }
+
+  if (options.sessionToken) {
+    params.set("session_token", options.sessionToken);
+  }
+
+  const url = `${MAPBOX_GEOCODING_URL}/${encodeURIComponent(query)}.json?${params.toString()}`;
+  const response = await fetch(url, {
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Mapbox Places request failed (${response.status}): ${body || response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as MapboxGeocodingResponse;
+  return data.features ?? [];
+}
+
+export function normalizeMapboxFeature(
+  feature: MapboxFeature,
+): StructuredLocation {
+  const [longitude, latitude] = feature.geometry.coordinates;
+  const mapBounds = bboxToBounds(feature.bbox ?? feature.geometry.bbox);
+
+  return {
+    name: feature.text,
+    address: feature.place_name,
+    placeId: feature.id,
+    provider: "mapbox",
+    latitude,
+    longitude,
+    mapBounds,
+    locationConfidence: normalizeRelevance(feature.relevance),
+    lastVerifiedAt: new Date().toISOString(),
+    raw: feature,
+  };
+}
+
+export function buildSuggestionLocationPayload(
+  feature: MapboxFeature,
+): SuggestionLocationPayload {
+  const structured = normalizeMapboxFeature(feature);
+
+  return {
+    location: structured.address ?? structured.name,
+    structured_location: {
+      name: structured.name,
+      address: structured.address,
+      place_id: structured.placeId,
+      provider: structured.provider,
+      map_bounds: structured.mapBounds,
+      location_confidence: structured.locationConfidence,
+      location_last_verified_at: structured.lastVerifiedAt,
+      raw: structured.raw,
+    },
+    latitude: structured.latitude,
+    longitude: structured.longitude,
+    map_bounds: structured.mapBounds,
+    geo_source: structured.provider,
+    location_confidence: structured.locationConfidence,
+    location_last_verified_at: structured.lastVerifiedAt,
+  };
+}
+
+function bboxToBounds(bbox?: MapboxBbox): MapBounds | undefined {
+  if (!bbox) return undefined;
+
+  const [west, south, east, north] = bbox;
+  return {
+    southwest: { latitude: south, longitude: west },
+    northeast: { latitude: north, longitude: east },
+  };
+}
+
+function normalizeRelevance(relevance?: number): number | undefined {
+  if (typeof relevance !== "number") {
+    return undefined;
+  }
+  return Math.max(0, Math.min(100, Math.round(relevance * 100)));
+}

--- a/frontend/app/types/location.ts
+++ b/frontend/app/types/location.ts
@@ -1,0 +1,64 @@
+export type Coordinate = {
+  latitude: number;
+  longitude: number;
+};
+
+export type MapBounds = {
+  northeast: Coordinate;
+  southwest: Coordinate;
+};
+
+export type LocationMetadata = {
+  /** Canonical display name (e.g., venue or neighborhood). */
+  name: string;
+  /** Full address or provider-formatted place label. */
+  address?: string;
+  /** Provider-specific identifier (Mapbox feature id, Google place_id, etc.). */
+  placeId?: string;
+  /** Provider slug (e.g., "mapbox", "google"). */
+  provider?: string;
+  /** Optional bounding box used to fit map viewport (NE/SW pairs). */
+  mapBounds?: MapBounds;
+  /** Optional confidence score (0-100) if supplied by the provider. */
+  locationConfidence?: number;
+  /** ISO timestamp for future revalidation flows. */
+  lastVerifiedAt?: string;
+  /** Raw provider payload for auditing/debugging. */
+  raw?: Record<string, unknown>;
+};
+
+export type StructuredLocation = LocationMetadata & Coordinate;
+
+export type LocationPickerValue = {
+  structured?: StructuredLocation;
+  /** Raw human-entered fallback string preserved for display/logging. */
+  freeform?: string;
+};
+
+export type StructuredLocationPayload = {
+  structured_location?: {
+    name: string;
+    address?: string;
+    place_id?: string;
+    provider?: string;
+    map_bounds?: MapBounds;
+    location_confidence?: number;
+    location_last_verified_at?: string;
+    raw?: Record<string, unknown>;
+  };
+  latitude?: number;
+  longitude?: number;
+  map_bounds?: MapBounds;
+  geo_source?: string;
+  location_confidence?: number;
+  location_last_verified_at?: string;
+};
+
+export type SuggestionLocationPayload = StructuredLocationPayload & {
+  location?: string;
+};
+
+export type NormalizedLocationSelection = {
+  picker: LocationPickerValue;
+  payload: SuggestionLocationPayload;
+};

--- a/location_picker_plan.md
+++ b/location_picker_plan.md
@@ -1,0 +1,104 @@
+# Location Picker Rollout Plan
+
+## Purpose
+Create an incremental plan for enabling structured location selection on suggestions so they can be plotted on a shared map, starting with the Supabase schema updates.
+
+## Guiding Principles
+- Favor additive schema changes to avoid downtime.
+- Keep Supabase as source of truth; synchronize SQLite + SQLAlchemy afterwards.
+- Maintain backwards compatibility by keeping existing `location` free-text field until migration completes.
+- Ship feature behind a feature flag until end-to-end experience is validated.
+
+## Current State Snapshot
+- Suggestions store only a `location` string with no coordinates.
+- Map view lacks stable identifiers for plotting suggestions.
+
+## Desired Capabilities
+1. Store canonical geospatial metadata from a location picker/autocomplete provider.
+2. Allow future filtering/aggregation (distance, clustering) without re-geocoding.
+3. Provide enough information to render pins on a client-rendered map.
+4. Preserve original human-readable description for display and auditing.
+
+## Data Model Additions (per `suggestions` table)
+| Column | Type | Nullable | Notes |
+| --- | --- | --- | --- |
+| `structured_location` | JSONB | ✅ | Stores normalized payload (name, address, place_id, provider metadata).
+| `latitude` | double precision | ✅ | Decimal degrees, SRID 4326.
+| `longitude` | double precision | ✅ | Decimal degrees, SRID 4326.
+| `map_bounds` | JSONB | ✅ | Optional NE/SW bounds for viewport fitting.
+| `geo_source` | text | ✅ | Provider slug (e.g., `mapbox`, `google`).
+| `location_confidence` | integer | ✅ | Optional ranking (0-100) from provider.
+| `location_last_verified_at` | timestamptz | ✅ | For future revalidation flows.
+
+### Derived/Support Structures
+- Create a partial index on (`picklejar_id`, `latitude`, `longitude`) where both coords are not null to accelerate map queries.
+- Add a check constraint enforcing lat/long bounds (lat between -90 and 90, lng between -180 and 180).
+- Optionally introduce a materialized view later for heatmaps; not part of v1.
+
+## Phase Breakdown
+### Phase 0 – Planning (you are here)
+- Finalize schema plan with stakeholders.
+- Confirm which provider will power autocomplete (likely Mapbox Places).
+- Document fallback behavior when structured data is unavailable.
+
+### Phase 1 – Supabase Schema Update
+1. Draft SQL in repo under `sql/supabase/20240914_add_structured_location.sql`.
+2. SQL should:
+   - `ALTER TABLE suggestions ADD COLUMN ...` for each field above.
+   - Backfill `structured_location` with `{ "name": location }` when only free text exists.
+   - Add the spatial check constraint and partial index.
+3. Run SQL in Supabase SQL Editor (or CLI) against production.
+4. Export executed SQL and commit to repo for reproducibility.
+5. Mirror changes to SQLite (either via raw SQL or SQLAlchemy metadata update) to keep dev env working.
+
+### Phase 2 – Backend Alignment
+- Update SQLAlchemy `Suggestion` model to include new columns.
+- Extend Pydantic schemas (`SuggestionCreate`, `SuggestionResponse`, etc.) to accept/return structured fields.
+- Gate acceptance behind `ENABLE_STRUCTURED_LOCATION` env flag; when disabled, backend ignores structured payload.
+- Add validation to ensure lat/long accompany structured payload.
+- Update API docs and automated tests to cover the new schema.
+
+### Phase 3 – Location Picker Integration
+- Select provider SDK (Mapbox GL JS + Geocoding API likely).
+- Build frontend component for suggestion form with autocomplete + map preview.
+- Normalize provider response into backend contract before submission.
+- Handle manual entry fallback when autocomplete fails.
+- Log provider errors to aid debugging.
+
+### Phase 4 – Map Visualization
+- Update jar detail page to request suggestions including coordinates.
+- Render pins on map (Mapbox/MapLibre) with clustering toggle.
+- Provide tooltip linking back to suggestion detail.
+- Consider heatmap/overlap view for future iteration.
+
+### Phase 5 – Rollout & Telemetry
+- Enable feature flag for internal team jars.
+- Monitor Supabase metrics: % of suggestions with coordinates, error rates.
+- Add analytics events for picker open, selection, submission.
+- Once stable, remove flag and require structured location for new suggestions.
+
+## Risk & Mitigation
+| Risk | Mitigation |
+| --- | --- |
+| API key exposure | Proxy autocomplete requests through backend/Supabase Edge Function; store secrets server-side. |
+| Partial data submissions | Keep free-text `location` as fallback; backend accepts structured payload only when complete. |
+| Performance impact on queries | Add partial index and query only non-null coordinates for map views. |
+| Migration drift between Supabase and SQLite | Commit SQL file + update SQLAlchemy models in same PR; run local migrations in CI. |
+
+## Success Criteria
+- ≥90% of new suggestions capture structured coordinates.
+- Map view renders pins without manual data massaging.
+- Supabase schema + repo migration scripts stay in sync.
+- No regression in existing suggestion creation flow.
+
+## Progress (2024-09-14)
+- Supabase production schema now includes structured-location columns, lat/lng constraint, and the partial index; the executed SQL lives in `sql/supabase/20240914_add_structured_location.sql`.
+- SQLAlchemy `Suggestion` model and Pydantic schemas expose the new fields so local development matches Supabase.
+- A backend feature flag (`ENABLE_STRUCTURED_LOCATION`) plus router validation ensures structured payloads are only accepted when the flag is enabled and lat/lng are provided together.
+- The frontend `/jar/[id]/suggest` flow now has a Mapbox-powered location picker behind `NEXT_PUBLIC_ENABLE_STRUCTURED_LOCATION`, with normalized payload helpers and README env doc updates so devs can test the structured-location data path end to end.
+
+## Next Action Items
+1. Capture the decision to defer rebuilding the local SQLite database (production Supabase already reflects the structured-location schema) and note when we'll regenerate the local file alongside upcoming migration work.
+2. Expand backend test coverage and API docs to reflect the structured-location contract and feature flag behavior.
+3. QA the Mapbox location picker (error/loading states, manual fallback, feature-flag toggles) and prep telemetry so we know when to roll it out beyond internal jars.
+4. Design the map visualization update (data fetching contract, clustering rules) in parallel so plotting can follow immediately after picker data flows in.

--- a/sql/supabase/20240914_add_structured_location.sql
+++ b/sql/supabase/20240914_add_structured_location.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- 1. Add new columns (all nullable for backward compatibility)
+ALTER TABLE public.suggestions
+    ADD COLUMN structured_location JSONB,
+    ADD COLUMN latitude DOUBLE PRECISION,
+    ADD COLUMN longitude DOUBLE PRECISION,
+    ADD COLUMN map_bounds JSONB,
+    ADD COLUMN geo_source TEXT,
+    ADD COLUMN location_confidence INTEGER,
+    ADD COLUMN location_last_verified_at TIMESTAMPTZ;
+
+-- 2. Seed structured_location with existing free-text value when possible
+UPDATE public.suggestions
+SET structured_location = jsonb_build_object('name', location)
+WHERE structured_location IS NULL
+  AND COALESCE(TRIM(location), '') <> '';
+
+-- 3. Enforce valid latitude/longitude pairs
+ALTER TABLE public.suggestions
+    ADD CONSTRAINT suggestions_lat_lng_bounds CHECK (
+        (latitude IS NULL AND longitude IS NULL)
+        OR (
+            latitude BETWEEN -90 AND 90
+            AND longitude BETWEEN -180 AND 180
+        )
+    );
+
+-- 4. Partial index to accelerate map lookups
+CREATE INDEX IF NOT EXISTS idx_suggestions_picklejar_lat_lng
+    ON public.suggestions (picklejar_id, latitude, longitude)
+    WHERE latitude IS NOT NULL AND longitude IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Introduces structured location fields to the Suggestion model and API, including latitude, longitude, map bounds, and provider metadata. Adds a feature flag (ENABLE_STRUCTURED_LOCATION) to control rollout, updates backend validation and schemas, and implements a Mapbox-powered location picker in the frontend behind NEXT_PUBLIC_ENABLE_STRUCTURED_LOCATION. Supabase schema migration and documentation are included to support incremental rollout and maintain backward compatibility.